### PR TITLE
amount can now be interpreted even with a comma

### DIFF
--- a/money-money-girocode/ScanController.swift
+++ b/money-money-girocode/ScanController.swift
@@ -137,7 +137,10 @@ extension GiroCode {
     static func parseAmount(s: String?) -> Double? {
         if let amountStr = s, amountStr.count > 4 {
             let index = amountStr.index(amountStr.startIndex, offsetBy: 3)
-            return Double(String(amountStr[index...]).trimmingCharacters(in: .whitespacesAndNewlines))
+            let numberString = String(amountStr[index...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: ",", with: ".") //now also works with dot in amountString
+            return Double(numberString)
         } else {
             return nil
         }


### PR DESCRIPTION
had "EUR30,00" in my amount field - problem was the '," - not it works with ',' AND '.'